### PR TITLE
Fix issue with reduce no longer performing magic

### DIFF
--- a/lib/PBKDF2.rakumod
+++ b/lib/PBKDF2.rakumod
@@ -9,7 +9,7 @@ multi pbkdf2(blob8 $password, :&prf, Str :$salt, :$c, :$dkLen) { samewith $passw
 multi pbkdf2(blob8 $key, :&prf, blob8 :$salt, :$c, :$dkLen) {
   (1..*)
   .map({
-    reduce * ~^ *,
+    reduce -> $a, $b? { $b.defined ?? $a ~^ $b !! $a },
       ($salt ~ blob8.new(.polymod(256 xx 3).reverse),
 	{ prf $_, $key } ... *)[1..$c]
   })


### PR DESCRIPTION
The "operator" of a &reduce must be able to accept 1 and 0 arg cases as well.  The block specified for the reduce wasn't able to do that, and started failing in tests since

  https://github.com/rakudo/rakudo/commit/9bcb01e966d2b29c103faa32ba880e2ab444648c

which showed up in https://github.com/rakudo/rakudo/issues/5783